### PR TITLE
feat: movies refetch when filters change

### DIFF
--- a/src/app/api/omdb_api.ts
+++ b/src/app/api/omdb_api.ts
@@ -3,7 +3,6 @@ import { Genre, Movie, MovieDetails, MoviesRequest } from "../utils/types";
 import axios from "axios";
 import { use } from "react";
 
-
 export function useFetchMovieDetails(
   movieID: number
 ): UseQueryResult<MovieDetails, Error> {
@@ -23,25 +22,30 @@ export function useFetchMovieDetails(
 
 export function useFetchMovies(
   search: string,
-  pageNum: string
+  pageNum: string,
+  filters?: string | null
 ): UseQueryResult<MoviesRequest, Error> {
-  console.log(`USE FETCH MOVIES SEARCH: ${search} ${pageNum}`);
   const query = useQuery<MoviesRequest, Error>({
     staleTime: Infinity,
-    queryKey: ["movies", search, pageNum],
+    queryKey: ["movies", search, pageNum, filters],
     queryFn: async () => {
       if (search && pageNum) {
-        console.log("SEARCH IS NOT NULL");
         const { data: searchResultsData } = await axios.get(
           `https://api.themoviedb.org/3/search/movie?query=${search}&page=${pageNum}&api_key=55de493263803a10375dd886602812d9`
         );
         return searchResultsData;
       } else {
-        console.error("SEARCH IS NULL/EMPTY");
-        const { data: discoverMoviesData } = await axios.get(
-          `https://api.themoviedb.org/3/discover/movie?api_key=55de493263803a10375dd886602812d9`
-        );
-        return discoverMoviesData;
+        if (filters) {
+          const { data: discoverMoviesDataWithFilters } = await axios.get(
+            `https://api.themoviedb.org/3/discover/movie?with_genres=${filters}&api_key=55de493263803a10375dd886602812d9`
+          );
+          return discoverMoviesDataWithFilters;
+        } else {
+          const { data: discoverMoviesData } = await axios.get(
+            `https://api.themoviedb.org/3/discover/movie?api_key=55de493263803a10375dd886602812d9`
+          );
+          return discoverMoviesData;
+        }
       }
     },
   });
@@ -98,4 +102,3 @@ export function useFetchAllGenres() {
 //   });
 //   return queries;
 // }
-

--- a/src/app/components/DiscoverMovies.tsx
+++ b/src/app/components/DiscoverMovies.tsx
@@ -3,6 +3,7 @@ import { Genre, Movie } from "../utils/types";
 import { IconFilterFilled } from "@tabler/icons-react";
 import FilterDialog from "./FilterDialog";
 import { useFilterDialogContext } from "../contexts/FilterDialogContext";
+import { useSearchParams } from "next/navigation";
 
 type DiscoverMoviesProps = {
   movies: Movie[];
@@ -15,13 +16,15 @@ export default function DiscoverMovies({
 }: DiscoverMoviesProps) {
 
   const {isOpen, setIsOpen} = useFilterDialogContext()
+  const searchParams = useSearchParams()
+  const filters = searchParams.get("with_genres")
   
   return (
     <div className="min-h-screen bg-gray-950 pt-[18vh] px-24 pb-24">
       <FilterDialog allGenres={allGenres}></FilterDialog>
       <div className="flex gap-8 items-center mb-8">
         <h1 className="text-white text-[2.5vw] overflow-hidden before:block before:h-8 before:w-[0.45rem] before:bg-purple-500 flex items-center gap-4">
-          Discover Movies
+          {filters ? "Showing filter results": "Discover Movies"}
         </h1>
         <button onClick={()=>setIsOpen(true)} type="button" className="px-6 py-2 bg-purple-500 rounded-full flex items-center gap-3 hover:bg-purple-800 group">
           <p className="text-white">Filters</p>

--- a/src/app/components/FilterDialog.tsx
+++ b/src/app/components/FilterDialog.tsx
@@ -23,20 +23,20 @@ export default function FilterDialog({ allGenres }: FilterDialogProps) {
 
   const [filters, setFilters] = useState<any[]>([]);
   const { isOpen, setIsOpen } = useFilterDialogContext();
-
   //get `with_genres` urlparams (if any) and convert to number array
-  const URLParamsFiltersArray = params
+  const URLParamsFiltersArray = searchParams
     .get("with_genres")
     ?.split(",")
     .map((filter) => Number(filter));
 
   useEffect(() => {
-    console.log("use effect ran");
-    //if with_genres params exists, set filters to that
+    //if with_genres params exists, set filters to that, otherwise empty the filters.
     if (URLParamsFiltersArray) {
       setFilters(URLParamsFiltersArray);
+    } else {
+      setFilters([]);
     }
-  }, []);
+  }, [searchParams, isOpen]);
 
   const handleSelectGenre = (genreID: number) => {
     //remove selected filter in filters if it exists, otherwise add
@@ -45,9 +45,7 @@ export default function FilterDialog({ allGenres }: FilterDialogProps) {
     } else {
       setFilters([...filters, genreID]);
     }
-    console.log(filters);
   };
-
 
   //this function returns:
   //true if [1,2,3]===[1,2,3,4] false if [1,2,3]===[3,2,1]
@@ -68,9 +66,7 @@ export default function FilterDialog({ allGenres }: FilterDialogProps) {
       return true;
     }
   }
-  //comment
-  //test
-  //comment
+
   return (
     <Dialog open={isOpen} onOpenChange={() => setIsOpen(false)}>
       <DialogContent className="bg-gray-950 border-gray-950">
@@ -99,18 +95,17 @@ export default function FilterDialog({ allGenres }: FilterDialogProps) {
                 //and prev and current filters are the same, so just close the dialog to avoid unnecessary fetch.
                 //3.if filters.length===0 and arrays are unequal, this means with_genres in url has filters
                 //but user cleared filters in the dialog, so clear filters by deleting with_genres in urlsearchparams.
-                if(checkArrayInequality(URLParamsFiltersArray, filters)){
-                  if(filters.length!==0){
-                    params.set("with_genres", filters.join(","))
-                  }
-                  else{
-                    params.delete("with_genres")
+                if (checkArrayInequality(URLParamsFiltersArray, filters)) {
+                  if (filters.length !== 0) {
+                    params.set("with_genres", filters.join(","));
+                  } else {
+                    params.delete("with_genres");
                   }
                 }
               } catch (e) {
                 throw new Error(`${e}`);
               } finally {
-                router.replace(`${pathname}?${params.toString()}`);
+                router.push(`${pathname}?${params.toString()}`);
                 setIsOpen(false);
               }
             }}

--- a/src/app/components/Movies.tsx
+++ b/src/app/components/Movies.tsx
@@ -18,7 +18,7 @@ export default function Movies() {
     isLoading: moviesReqLoading,
     isError: moviesReqIsError,
     error: moviesReqError,
-  } = useFetchMovies(searchQuery!, pageNum!);
+  } = useFetchMovies(searchQuery!, pageNum!, filters);
   const {
     data: allGenres,
     isLoading: allGenresLoading,

--- a/src/app/components/Search.tsx
+++ b/src/app/components/Search.tsx
@@ -12,6 +12,7 @@ export default function Search() {
   const handleSearch = useDebouncedCallback((searchTerm: string) => {
     const params = new URLSearchParams(searchParams);
     if (searchTerm) {
+      // params.delete("with_genres")
       paramsSetAllFromObj(
         [
           ["query", searchTerm],

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
closes #27 
In this commit, I added filters (with_genres in URL) as a dependency in useFetchMovies and returning movies with filters when there are filters applied. In the FilterDialog component, I changed URLParamsFilterArray to make an array using searchParams instead of ew URLSearchParams
since if I add the params as a dependency, it will cause an infinite loop since a new URLSearchParams will be made everytime. I used searchParams since it is read-only. I also added isOpen to the dependency array so that when user changes filters but chooses not to confirm, when the user opens the dialog again, the filters state are reset back to the filters in the URL.