### PR TITLE
fix: handle back button when searching after filtering

### DIFF
--- a/src/app/components/DiscoverMovies.tsx
+++ b/src/app/components/DiscoverMovies.tsx
@@ -14,19 +14,27 @@ export default function DiscoverMovies({
   movies,
   allGenres,
 }: DiscoverMoviesProps) {
+  const {isOpen, setIsOpen} = useFilterDialogContext();
+  const searchParams = useSearchParams();
+  const filters = searchParams.get("with_genres");
 
-  const {isOpen, setIsOpen} = useFilterDialogContext()
-  const searchParams = useSearchParams()
-  const filters = searchParams.get("with_genres")
-  
   return (
     <div className="min-h-screen bg-gray-950 pt-[18vh] px-24 pb-24">
       <FilterDialog allGenres={allGenres}></FilterDialog>
       <div className="flex gap-8 items-center mb-8">
         <h1 className="text-white text-[2.5vw] overflow-hidden before:block before:h-8 before:w-[0.45rem] before:bg-purple-500 flex items-center gap-4">
-          {filters ? "Showing filter results": "Discover Movies"}
+          {filters ? "Showing filter results" : "Discover Movies"}
         </h1>
-        <button onClick={()=>setIsOpen(true)} type="button" className="px-6 py-2 bg-purple-500 rounded-full flex items-center gap-3 hover:bg-purple-800 group">
+        <button
+          onClick={() => setIsOpen(true)}
+          type="button"
+          className="px-6 py-2 bg-purple-500 rounded-full flex items-center gap-3 hover:bg-purple-800 group relative"
+        >
+          {filters && (
+            <div className="box-content p-2 rounded-full text-gray-700 bg-yellow-400 absolute -top-2 -right-10 text-[10px]">
+              {`${filters.split(",").length || 0} selected`}
+            </div>
+          )}
           <p className="text-white">Filters</p>
           <IconFilterFilled color="white" size={25} />
         </button>
@@ -37,7 +45,7 @@ export default function DiscoverMovies({
           return (
             <div key={movie.id} className="overflow-hidden">
               <MovieCard movie={movie} allGenres={allGenres}/>
-            </div>
+            </div >
           );
         })}
       </div>

--- a/src/app/components/Search.tsx
+++ b/src/app/components/Search.tsx
@@ -17,7 +17,7 @@ export default function Search() {
   const handleSearch = useDebouncedCallback((searchTerm: string) => {
     const params = new URLSearchParams(searchParams);
     if (searchTerm) {
-      // params.delete("with_genres")
+      params.delete("with_genres")
       paramsSetAllFromObj(
         [
           ["query", searchTerm],


### PR DESCRIPTION
closes #40 
In this commit I fixed the issue of genres being removed when clicking back button when you search for a movie after applying filters.

I also added an indicator in the filters that tells the user how many filers are applied.